### PR TITLE
fix: Edge web fullscreen SC not showing

### DIFF
--- a/entrypoints/fullScreen.content/observePageFullScreen.tsx
+++ b/entrypoints/fullScreen.content/observePageFullScreen.tsx
@@ -26,7 +26,7 @@ function listenVideoSizeChange(video: HTMLVideoElement) {
     for (const entry of entries) {
       if (entry.contentRect) {
         const videoWidth = entry.contentRect?.width
-        if (videoWidth === window.innerWidth) {
+        if (Math.abs(videoWidth - window.innerWidth) < 2) {
           // 虽然宽度相同，但是有可能窗口resize也会进来，所以为了防止重复mount
           if (!lastTimePageFullScreen) {
             // 全屏模式下跳另一种全屏，要做校验是否已经处于全屏模式
@@ -34,7 +34,7 @@ function listenVideoSizeChange(video: HTMLVideoElement) {
               lastTimePageFullScreen = true
           }
         }
-        else if (lastTimePageFullScreen && videoWidth) {
+        else if (lastTimePageFullScreen && videoWidth && Math.abs(videoWidth - window.innerWidth) >= 2) {
           unmount('------退出了网页全屏模式------')
           lastTimePageFullScreen = false
         }


### PR DESCRIPTION
## Problem
In Edge browser, Super Chat (SC) does not display in web fullscreen mode.

## Root Cause
In observePageFullScreen.tsx, strict equality (===) is used to compare videoWidth and window.innerWidth. Edge sub-pixel rendering causes a tiny difference (e.g. 0.5px) between the two values, so the strict equality check fails and the web fullscreen state is not detected correctly.

## Fix
Replace strict equality with a tolerance check (less than 2px):
- videoWidth === window.innerWidth changed to Math.abs(videoWidth - window.innerWidth) less than 2
- Exit condition updated accordingly